### PR TITLE
Hotfix startup issues

### DIFF
--- a/lua/lab/init.lua
+++ b/lua/lab/init.lua
@@ -20,7 +20,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 local Process = require 'lab.process'
 local CodeRunner = require 'lab.code_runner'
-local QuickData = require 'lab.quick_data'
 
 local Lab = {}
 local state = { active = false }
@@ -36,8 +35,8 @@ local default_opts = {
 
 function Lab.setup(opts)
 	if state.active == true then return end
-
-	opts = vim.tbl_deep_extend('force', default_opts, opts)
+	
+	opts = vim.tbl_deep_extend('force', default_opts, opts or {})
 
 	if opts.code_runner.enabled or opts.quick_data.enabled then
 		Process:start()
@@ -48,7 +47,12 @@ function Lab.setup(opts)
 	end
 
 	if opts.quick_data.enabled then
-		QuickData.setup(opts)
+		local has_cmp, cmp = pcall(require, 'cmp')
+		if has_cmp then
+			require('lab.quick_data').init()
+		else
+			vim.notify("Quick data feature requires nvim cmp", "error", { title = "Lab.nvim"});
+		end
 	end
 
 	state.active = true;

--- a/lua/lab/quick_data.lua
+++ b/lua/lab/quick_data.lua
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 local Process = require 'lab.process'
 local QuickDataComp = require 'lab.quick_data_cmp'
+local cmp = require 'cmp'
 
 local QuickData = {
 	handlers = {},
@@ -34,16 +35,7 @@ Process:register(function(msg)
 	end;
 end)
 
-function QuickData.setup(opts)
-	local has_cmp, cmp = pcall(require, 'cmp')
-	if has_cmp then
-		QuickData.init(cmp)
-	else
-		vim.notify("Quick data feature requires nvim cmp", "error", { title = "Lab.nvim"});
-	end
-end
-
-function QuickData.init(cmp)
+function QuickData.init()
 	local id = "quickdata.init"
 	cmp.register_source('lab.quick_data', QuickDataComp.new())
 	local initHandler = function(data)


### PR DESCRIPTION
- Properly detect nvim-cmp availability
- Properly instantiate the setup options as an empty table if no options are provided.