### PR TITLE
Maintenance

### DIFF
--- a/js/dist/index.js
+++ b/js/dist/index.js
@@ -21,7 +21,7 @@ import jsonrpc from 'jsonrpc-lite';
 import { print } from './util/index.js';
 import { rpcRouter as rpc } from './rpc-router.js';
 import { runner } from './runner.js';
-import { refresh as quickDataRefresh, dataFilePath as quickDataPath } from './quick-data/quick-data.js';
+import { refresh as quickDataRefresh, dataFilePath as quickDataPath, generate as quickDataGenerate } from './quick-data/quick-data.js';
 import { CodeRunnerMethod, ConfigMethod, QuickDataMethod } from './constants.js';
 var LANG;
 (function (LANG) {
@@ -54,8 +54,9 @@ rpc.request(CodeRunnerMethod.Resume, (message) => {
         print(jsonrpc.success(message.payload.id, LANG.STATUS_OK));
     }
 });
-rpc.request(ConfigMethod.Get, (message) => {
+rpc.request(ConfigMethod.Get, async (message) => {
     if (message.payload.params.key === 'quick.data.source') {
+        await quickDataGenerate();
         print(jsonrpc.success(message.payload.id, { path: quickDataPath }));
     }
     else {

--- a/js/dist/processors/esbuild.d.ts
+++ b/js/dist/processors/esbuild.d.ts
@@ -1,2 +1,3 @@
-declare function _default(filePath: any): Promise<any>;
+import type { PreProcessorResult } from '../types.js';
+declare const _default: (filePath: string) => Promise<PreProcessorResult>;
 export default _default;

--- a/js/dist/quick-data/quick-data.js
+++ b/js/dist/quick-data/quick-data.js
@@ -84,4 +84,3 @@ export const refresh = (mod, method) => {
     }
     return null;
 };
-generate();

--- a/js/dist/runner.d.ts
+++ b/js/dist/runner.d.ts
@@ -3,7 +3,7 @@ export declare const runner: {
     instances: Map<any, any>;
     start: (args: RunnerParams) => Promise<[false, string] | [true]>;
     invokePreprocessing(args: RunnerParams, config: CodeRunnerConfig): Promise<{
-        filePath: any;
+        filePath: string;
         useSourceMap: boolean;
     }>;
     stop(args: Omit<RunnerParams, 'config'>): [false, string] | [true];

--- a/js/dist/types.d.ts
+++ b/js/dist/types.d.ts
@@ -38,5 +38,8 @@ export interface CodeRunnerNotification {
     text: string;
     description?: string;
 }
+declare type PreProcessorSuccess = [string, false];
+declare type PreProcessorError = [CodeRunnerNotification, true];
+export declare type PreProcessorResult = PreProcessorSuccess | PreProcessorError;
 export declare type GenericCallback = (...args: any[]) => any;
 export {};

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -22,7 +22,7 @@ import jsonrpc from 'jsonrpc-lite';
 import { print } from '@/util/index.js';
 import { rpcRouter as rpc } from '@/rpc-router.js';
 import { runner } from '@/runner.js';
-import { refresh as quickDataRefresh, dataFilePath as quickDataPath } from '@/quick-data/quick-data.js';
+import { refresh as quickDataRefresh, dataFilePath as quickDataPath, generate as quickDataGenerate } from '@/quick-data/quick-data.js';
 import type { CodeRunnerMessage, ConfigMessage, QuickDataMessage} from '@/types.js';
 import { CodeRunnerMethod, ConfigMethod, QuickDataMethod } from '@/constants.js';
 
@@ -57,8 +57,9 @@ rpc.request(CodeRunnerMethod.Resume, (message: CodeRunnerMessage) => {
 	}
 });
 
-rpc.request(ConfigMethod.Get, (message: ConfigMessage) => {
+rpc.request(ConfigMethod.Get, async (message: ConfigMessage) => {
 	if (message.payload.params.key === 'quick.data.source') {
+		await quickDataGenerate();
 		print(jsonrpc.success(message.payload.id, { path: quickDataPath }));
 	} else {
 		print(jsonrpc.error(message.payload.id, new jsonrpc.JsonRpcError('Unrecognized key', 104)));

--- a/js/src/processors/esbuild.ts
+++ b/js/src/processors/esbuild.ts
@@ -19,14 +19,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import esbuild from 'esbuild';
-import path from 'node:path';
-import fs from 'node:fs/promises';
-import os from 'node:os';
+import { BuildFailure } from 'esbuild';
+import * as path  from 'node:path';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import { logger } from '@/util/logging.js';
+import type { PreProcessorResult } from '@/types.js';
 
 const log = logger('esbuild');
 
-export default async (filePath) => {
+export default async (filePath: string): Promise<PreProcessorResult> => {
 	try {
 		const fileName = path.basename(filePath).replace(path.extname(filePath), '.js');
 		const tmpPath = await fs.realpath(os.tmpdir());
@@ -43,9 +45,26 @@ export default async (filePath) => {
 			outfile: outPath,
 			logLevel: 'silent',
 		});
-		return outPath;
+		return [outPath, false];
 	}
 	catch(err) {
-		throw new Error('esbuild failed');
+		
+		const buildError = err as BuildFailure;
+
+		if ('errors' in buildError && Array.isArray(buildError.errors) && buildError.errors.length) {
+			
+			const [errorInfo] = buildError.errors;
+			
+			return [{
+				event: 'error',
+				text: errorInfo?.text ?? '',
+				description: '',
+				line: errorInfo?.location?.line ? errorInfo.location.line - 1 : 0,
+				col: errorInfo?.location?.column ?? 0,
+			}, true];
+
+		} else {
+			throw err;
+		}
 	}
 };

--- a/js/src/quick-data/quick-data.js
+++ b/js/src/quick-data/quick-data.js
@@ -88,5 +88,3 @@ export const refresh = (mod, method) => {
 	}
 	return null;
 };
-
-generate();

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -45,7 +45,6 @@ export type CodeRunnerMessage = RPCMessage<RunnerParams>;
 export type QuickDataMessage = RPCMessage<QuickDataParams>;
 export type ConfigMessage = RPCMessage<ConfigParams>;
 
-
 type Preprocessors = 'lab.esbuild';
 type Runners = 'lab.node' | 'lab.python' | 'lab.lua';
 
@@ -54,7 +53,6 @@ export interface CodeRunnerConfig {
 	preprocessors: Array<Preprocessors>,
 	runner: Runners,
 }
-
 
 export interface PreprocessingData {
 	filePath: string,
@@ -69,6 +67,10 @@ export interface CodeRunnerNotification {
 	text: string,
 	description?: string,
 }
+
+type PreProcessorSuccess = [string, false]
+type PreProcessorError = [CodeRunnerNotification, true]
+export type PreProcessorResult = PreProcessorSuccess | PreProcessorError;
 
 /* eslint-disable-next-line */
 export type GenericCallback = (...args: any[]) => any;

--- a/lua/lab/code_runner.lua
+++ b/lua/lab/code_runner.lua
@@ -31,7 +31,7 @@ local supported_file_types = {
 	["javascript"] = true,
 	["javascriptreact"] = true,
 	["typescript"] = true,
-	["typecriptreact"] = true,
+	["typescriptreact"] = true,
 	["python"] = true,
 	["lua"] = true,
 }
@@ -43,9 +43,13 @@ local state = {
 	unregister = nil,
 }
 
+local lang = {
+	disabled = 'The code runner is currently disabled. If this is unexpected, check that lab.setup is being called in your config.',
+}
+
 function CodeRunner.run()
 	if not state.active then 
-		vim.notify("CodeRunner is currently disabled.", "error", { title = "Lab.nvim"});
+		vim.notify(lang.disabled, "error", { title = "Lab.nvim" });
 		return
 	end
 
@@ -68,7 +72,7 @@ function CodeRunner.run()
 	-- Proceed only if the file type is supported.
 	local file_type = Filetype.detect(file_path);
 	if not supported_file_types[file_type] then
-		vim.notify("File type: " .. file_type .. " not supported.", "error", { title = "Lab.nvim"});
+		vim.notify("File type: " .. file_type .. " not supported.", "error", { title = "Lab.nvim" });
 		return
 	end
 
@@ -133,7 +137,7 @@ end
 
 function CodeRunner.stop()
 	if not state.active then 
-		vim.notify("CodeRunner is currently disabled.", "error", { title = "Lab.nvim"});
+		vim.notify(lang.disabled, "error", { title = "Lab.nvim" });
 		return
 	end
 	
@@ -170,7 +174,7 @@ end
 
 function CodeRunner.config()
 	if not state.active then 
-		vim.notify("CodeRunner is currently disabled.", "error", { title = "Lab.nvim"});
+		vim.notify(lang.disabled, "error", { title = "Lab.nvim" });
 		return
 	end
 	local file_path = api.nvim_buf_get_name(0)
@@ -179,7 +183,7 @@ end
 
 function CodeRunner.panel()
 	if not state.active then 
-		vim.notify("CodeRunner is currently disabled.", "error", { title = "Lab.nvim"});
+		vim.notify(lang.disabled, "error", { title = "Lab.nvim" });
 		return
 	end
 	if Panel.is_open then
@@ -204,6 +208,14 @@ function CodeRunner.setup(opts)
 end
 
 function CodeRunner.handler(msg)
+
+	if (msg.error) then
+		vim.defer_fn(function()
+			Panel:write("- " .. msg.error.message)
+			vim.notify(msg.error.message, "error", { title = "Lab.nvim"});
+		end, 1)
+		return
+	end
 
 	if not msg.method or not msg.method == "Lab.Runner.Feedback" then return end;
 

--- a/lua/lab/init.lua
+++ b/lua/lab/init.lua
@@ -51,7 +51,7 @@ function Lab.setup(opts)
 		if has_cmp then
 			require('lab.quick_data').init()
 		else
-			vim.notify("Quick data feature requires nvim cmp", "error", { title = "Lab.nvim"});
+			vim.notify("Quick data feature requires nvim cmp", "error", { title = "Lab.nvim" });
 		end
 	end
 

--- a/lua/lab/panel.lua
+++ b/lua/lab/panel.lua
@@ -34,7 +34,7 @@ function Panel:init()
 	api.nvim_buf_set_option(self.buf_handle, "buftype", "nofile")
 	api.nvim_buf_set_option(self.buf_handle, "swapfile", false)
 	api.nvim_buf_set_option(self.buf_handle, "buflisted", false)
-	api.nvim_buf_set_option(self.buf_handle, "filetype", "Markdown")
+	api.nvim_buf_set_option(self.buf_handle, "filetype", "markdown")
 	api.nvim_buf_set_option(self.buf_handle, "modifiable", false)
 	api.nvim_buf_set_option(self.buf_handle, "readonly", true)
 end

--- a/lua/lab/process.lua
+++ b/lua/lab/process.lua
@@ -52,18 +52,14 @@ function Process:start()
 
 			if not success then return end
 
-			if msg.error then
-				vim.notify(msg.error.message, "error", { title = "Lab.nvim"});
-				return
-			end
-
 			for key, handler in pairs(self.handlers) do
 				handler(msg)
 			end
 		end,
 
 		on_stderr = function (error, data)
-			print("stderr", vim.inspect(error), vim.inspect(data))
+			-- @Todo: Printing here will fail.
+			-- print("stderr", vim.inspect(error), vim.inspect(data))
 		end,
 	})
 	self.instance:start()


### PR DESCRIPTION
- Properly handle pre-processor (esbuild) errors when they occur by displaying them as inline syntax errors when possible.
- Properly handle any hard errors emitted from the code runner within the Lua handler. Previously the attempt to print the error would fail. (nvim_echo must not be called in a lua loop callback)
- Await quick data generation before responding with the quick data config. This prevents race conditions on subsequent access of the data.
- Add improved status message to help users understand why the code runner might not be enabled.
- Correct typo in `typescriptreact` so that it will be recognized as supported.
- Correct the panels file type to `markdown`, since the uppercase `M` seemed to be problematic for some users/systems.