### PR TITLE
Change panel filetype to prevent errors from Treesitter

### DIFF
--- a/lua/lab/panel.lua
+++ b/lua/lab/panel.lua
@@ -40,9 +40,8 @@ function Panel:init()
 end
 
 function Panel:open()
-
-	api.nvim_command('botright split lab')
-	api.nvim_command('setlocal nonumber norelativenumber')
+	api.nvim_command("botright split lab")
+	api.nvim_command("setlocal nonumber norelativenumber")
 	api.nvim_win_set_height(0, 10)
 
 	self.win_handle = api.nvim_tabpage_get_win(0)
@@ -66,12 +65,12 @@ end
 
 function Panel:modifiable(state)
 	api.nvim_buf_set_option(self.buf_handle, "modifiable", state)
-	api.nvim_buf_set_option(self.buf_handle, "readonly", (not state))
+	api.nvim_buf_set_option(self.buf_handle, "readonly", not state)
 end
 
 function Panel:write(text)
 	self:modifiable(true)
-	local lines = {text}
+	local lines = { text }
 	api.nvim_buf_set_lines(self.buf_handle, -1, -1, true, lines)
 	self:modifiable(false)
 	self:scrollToBottom()

--- a/lua/lab/panel.lua
+++ b/lua/lab/panel.lua
@@ -34,7 +34,7 @@ function Panel:init()
 	api.nvim_buf_set_option(self.buf_handle, "buftype", "nofile")
 	api.nvim_buf_set_option(self.buf_handle, "swapfile", false)
 	api.nvim_buf_set_option(self.buf_handle, "buflisted", false)
-	api.nvim_buf_set_option(self.buf_handle, "filetype", "markdown")
+	api.nvim_buf_set_option(self.buf_handle, "filetype", "text")
 	api.nvim_buf_set_option(self.buf_handle, "modifiable", false)
 	api.nvim_buf_set_option(self.buf_handle, "readonly", true)
 end


### PR DESCRIPTION
`Panel.lua` has previously been setting it's filetype to `markdown`. This PR changes the panel filetype to `text`to prevent the issues with Neovim's Treesitter markdown parsing (https://github.com/0x100101/lab.nvim/issues/16).

PR also has couple of lines formatting changes which my editor did automatically, they should not affect the functionality but if you want the original formatting for those lines I can revert the commit 0be67f6aa59b6e3275d4117209cc81e6088e604b.
