### PR TITLE
Updated symbols in node console preview

### DIFF
--- a/js/dist/runners/node/message-evaluators/console.js
+++ b/js/dist/runners/node/message-evaluators/console.js
@@ -29,7 +29,7 @@ const objPreview = {
     formatValue(item) {
         switch (item.type) {
             case 'function':
-                return '';
+                return '󰊕';
             case 'string':
                 return `"${item.value}"`;
             default:

--- a/js/dist/runners/node/msg-handlers.js
+++ b/js/dist/runners/node/msg-handlers.js
@@ -57,7 +57,7 @@ const objPreview = {
     formatValue(item) {
         switch (item.type) {
             case 'function':
-                return '';
+                return '󰊕';
             case 'string':
                 return `"${item.value}"`;
             default:

--- a/js/src/runners/node/message-evaluators/console.ts
+++ b/js/src/runners/node/message-evaluators/console.ts
@@ -40,7 +40,7 @@ const objPreview = {
 	formatValue(item: PreviewProp){
 		switch (item.type) {
 			case 'function':
-				return '';
+				return '󰊕';
 			case 'string':
 				return `"${item.value}"`;
 			default:

--- a/lua/lab/code_runner.lua
+++ b/lua/lab/code_runner.lua
@@ -272,7 +272,7 @@ function CodeRunner.handler(msg)
 				text = msg.params.text,
 				hl = 'DiagnosticVirtualTextWarn',
 				append = false,
-				icon = '',
+				icon = '󰏦',
 			})
 			Panel:write("- [" .. (msg.params.line + 1) .. "] " .. msg.params.text)
 		end, 1)

--- a/lua/lab/virtual_text.lua
+++ b/lua/lab/virtual_text.lua
@@ -31,7 +31,7 @@ function VirtualText:render(opts)
 	if not opts.line_num then return end
 	if not opts.run_id then return end
 
-	local default_opts = { icon = '', pos = 'eol', append = true, hl = 'DiagnosticVirtualTextHint' }
+	local default_opts = { icon = '󰅴', pos = 'eol', append = true, hl = 'DiagnosticVirtualTextHint' }
 
 	for k, v in pairs(default_opts) do
 		if opts[k] == nil then opts[k] = v end


### PR DESCRIPTION
Updated code tags symbol, function symbol, and circle pause symbol in node console preview to be compatible with v3.0.0 Nerd Fonts 

---

Nerd Fonts moved some symbols to new codepoints. This pull request attempts to update symbols I could find that no longer renders correctly in Nerd Fonts v3.0.0, and change them for their equivalents. 

Before:
![image](https://github.com/0x100101/lab.nvim/assets/44142407/d3d29e3e-26f7-4cbe-a8a0-120be42fb063)
After:
![image](https://github.com/0x100101/lab.nvim/assets/44142407/56de7656-28aa-4579-bada-6a4d5366edd6)

These screenshots are taken using `CaskaydiaCove NF Mono` from v3.0.2 
